### PR TITLE
Enable "portmap" plugin by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ ADD dist/host-local /opt/cni/bin/host-local
 ADD dist/vlan /opt/cni/bin/vlan
 
 ADD install-cni.sh /install-cni.sh
-ADD flannel.conf.default /flannel.conf.default
+ADD flannel.conflist.default /flannel.conflist.default

--- a/flannel.conf.default
+++ b/flannel.conf.default
@@ -1,7 +1,0 @@
-{
-    "name": "cbr0",
-    "type": "flannel",
-    "delegate": {
-    "isDefaultGateway": true
-    }
-}

--- a/flannel.conflist.default
+++ b/flannel.conflist.default
@@ -7,6 +7,12 @@
       "delegate": {
         "isDefaultGateway": true
       }
+    },
+    {
+      "type": "portmap",
+      "capabilities": {
+        "portMappings": true
+      }
     }
   ]
 }

--- a/flannel.conflist.default
+++ b/flannel.conflist.default
@@ -1,0 +1,12 @@
+{
+  "name": "cbr0",
+  "cniVersion": "0.3.1",
+  "plugins": [
+    {
+      "type": "flannel",
+      "delegate": {
+        "isDefaultGateway": true
+      }
+    }
+  ]
+}

--- a/install-cni.sh
+++ b/install-cni.sh
@@ -7,7 +7,7 @@ if [ -w "/host/opt/cni/bin/" ]; then
     echo "Wrote CNI binaries to /host/opt/cni/bin/";
 fi;
 
-TMP_CONF='/flannel.conf.default'
+TMP_CONF='/flannel.conflist.default'
 # If specified, overwrite the network configuration file.
 if [ "${CNI_NETWORK_CONFIG:-}" != "" ]; then
 cat >$TMP_CONF <<EOF
@@ -15,8 +15,12 @@ ${CNI_NETWORK_CONFIG:-}
 EOF
 fi
 
-FILENAME=${CNI_CONF_NAME:-10-flannel.conf}
-mv $TMP_CONF /host/etc/cni/net.d/${FILENAME}
-echo "Wrote CNI config: $(cat /host/etc/cni/net.d/${FILENAME})"
+CNI_CONF_NAME="${CNI_CONF_NAME:-10-flannel.conflist}"
+CNI_OLD_NAME="${CNI_OLD_NAME:-10-flannel.conf}"
+if [ "${CNI_CONF_NAME}" != "${CNI_OLD_NAME}" ]; then
+    rm -f "/host/etc/cni/net.d/${CNI_OLD_NAME}"
+fi
+mv $TMP_CONF /host/etc/cni/net.d/${CNI_CONF_NAME}
+echo "Wrote CNI config: $(cat /host/etc/cni/net.d/${CNI_CONF_NAME})"
 
 while :; do sleep 3600; done;


### PR DESCRIPTION
~~Not tested (yet) and https://github.com/coreos/flannel-cni/pull/3 should be merged first.~~

~~Config taken from here: https://github.com/kubernetes-incubator/kube-aws/issues/704#issuecomment-322051829 , ~~he say it isn't working, but that could be because of the [extension](https://github.com/kubernetes/kubernetes/issues/23920#issuecomment-308254308).~~ **Update:** It is [working](https://github.com/kubernetes-incubator/kube-aws/issues/704#issuecomment-323609993)~~