### PR TITLE
[NOT TESTED] Support running as init container

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,22 @@ spec:
         tier: node
         k8s-app: flannel
     spec:
+      initContainers:
+      - name: install-cni
+        image: quay.io/coreos/flannel-cni:0.1
+        command: ["/install-cni.sh"]
+        env:
+        # The CNI network config to install on each node.
+        - name: CNI_NETWORK_CONFIG
+            valueFrom:
+            configMapKeyRef:
+                name: kube-flannel-cfg
+                key: cni-conf.json
+        volumeMounts:
+        - name: cni
+          mountPath: /etc/cni/net.d
+        - name: host-cni-bin
+          mountPath: /host/opt/cni/bin/
       containers:
       - name: kube-flannel
         image: quay.io/coreos/flannel:v0.7.1-amd64
@@ -73,21 +89,6 @@ spec:
           mountPath: /etc/cni/net.d
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
-      - name: install-cni
-        image: quay.io/coreos/flannel-cni:0.1
-        command: ["/install-cni.sh"]
-        env:
-        # The CNI network config to install on each node.
-        - name: CNI_NETWORK_CONFIG
-            valueFrom:
-            configMapKeyRef:
-                name: kube-flannel-cfg
-                key: cni-conf.json
-        volumeMounts:
-        - name: cni
-          mountPath: /etc/cni/net.d
-        - name: host-cni-bin
-          mountPath: /host/opt/cni/bin/
       hostNetwork: true
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/install-cni.sh
+++ b/install-cni.sh
@@ -19,4 +19,6 @@ FILENAME=${CNI_CONF_NAME:-10-flannel.conf}
 mv $TMP_CONF /host/etc/cni/net.d/${FILENAME}
 echo "Wrote CNI config: $(cat /host/etc/cni/net.d/${FILENAME})"
 
-while :; do sleep 3600; done;
+if [ "${CNI_INSTALL_TYPE:-init}" == "container" ]; then
+    while :; do sleep 3600; done;
+fi


### PR DESCRIPTION
It make more sense to run the installation as a init container,
instant of installing and then sleeping forever.

The old behavior is still supported by setting:
CNI_INSTALL_TYPE=container

Require k8s 1.6<

Fix #8

---
I'm not sure if this should be opt-in or opt-out? Any input?