### PR TITLE
Fix indent on env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ spec:
         env:
         # The CNI network config to install on each node.
         - name: CNI_NETWORK_CONFIG
-            valueFrom:
+          valueFrom:
             configMapKeyRef:
                 name: kube-flannel-cfg
                 key: cni-conf.json


### PR DESCRIPTION
Fix the indent on the README example being wrong. 