### PR TITLE
build cni for more than just amd64

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -10,12 +10,14 @@ ARCH=$(uname -m)
 case $ARCH in
        aarch64)
                ARCHITECTURE=arm64
+	       $VERSION=$VERSION-$ARCHITECTURE
                ;;
        x86_64)
                ARCHITECTURE=amd64
                ;;
        *)
                ARCHITECTURE=$ARCH
+	       $VERSION=$VERSION-$ARCHITECTURE
                ;;
 esac
 

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -10,14 +10,15 @@ ARCH=$(uname -m)
 case $ARCH in
        aarch64)
                ARCHITECTURE=arm64
-	       $VERSION=$VERSION-$ARCHITECTURE
+	       VERSION_ARCH=$VERSION-$ARCHITECTURE
                ;;
        x86_64)
                ARCHITECTURE=amd64
+	       VERSION_ARCH=$VERSION
                ;;
        *)
                ARCHITECTURE=$ARCH
-	       $VERSION=$VERSION-$ARCHITECTURE
+	       VERSION_ARCH=$VERSION-$ARCHITECTURE
                ;;
 esac
 
@@ -25,5 +26,5 @@ mkdir -p dist
 $CURL -L --retry 5 https://github.com/containernetworking/cni/releases/download/$CNI_VERSION/cni-$ARCHITECTURE-$CNI_VERSION.tgz | tar -xz -C dist/
 $CURL -L --retry 5 https://github.com/containernetworking/plugins/releases/download/$CNI_VERSION/cni-plugins-$ARCHITECTURE-$CNI_VERSION.tgz | tar -xz -C dist/
 
-docker build --no-cache -t $IMAGE_NAME:$VERSION .
-docker push $IMAGE_NAME:$VERSION
+docker build --no-cache -t $IMAGE_NAME:$VERSION_ARCH .
+docker push $IMAGE_NAME:$VERSION_ARCH

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -5,10 +5,23 @@ FLANNEL_CNI_ROOT=$(git rev-parse --show-toplevel)
 IMAGE_NAME=quay.io/coreos/flannel-cni
 VERSION=$($FLANNEL_CNI_ROOT/scripts/git-version)
 CNI_VERSION="v0.6.0"
+ARCH=$(uname -m)
+
+case $ARCH in
+       aarch64)
+               ARCHITECTURE=arm64
+               ;;
+       x86_64)
+               ARCHITECTURE=amd64
+               ;;
+       *)
+               ARCHITECTURE=$ARCH
+               ;;
+esac
 
 mkdir -p dist
-$CURL -L --retry 5 https://github.com/containernetworking/cni/releases/download/$CNI_VERSION/cni-amd64-$CNI_VERSION.tgz | tar -xz -C dist/
-$CURL -L --retry 5 https://github.com/containernetworking/plugins/releases/download/$CNI_VERSION/cni-plugins-amd64-$CNI_VERSION.tgz | tar -xz -C dist/
+$CURL -L --retry 5 https://github.com/containernetworking/cni/releases/download/$CNI_VERSION/cni-$ARCHITECTURE-$CNI_VERSION.tgz | tar -xz -C dist/
+$CURL -L --retry 5 https://github.com/containernetworking/plugins/releases/download/$CNI_VERSION/cni-plugins-$ARCHITECTURE-$CNI_VERSION.tgz | tar -xz -C dist/
 
 docker build --no-cache -t $IMAGE_NAME:$VERSION .
 docker push $IMAGE_NAME:$VERSION


### PR DESCRIPTION
Before this change non-amd64 containers contained amd64 binaries. This
commit changes this behaviour. Some architectures like arm64 or amd64
report themself different with 'uname -m', thus this needs mapping to
the architecture named packages of cni and cni-plugins.

This should fix #10.